### PR TITLE
RA-10 bundle data transfer

### DIFF
--- a/app/src/main/java/com/example/recipesapp/CategoriesListAdapter.kt
+++ b/app/src/main/java/com/example/recipesapp/CategoriesListAdapter.kt
@@ -9,18 +9,11 @@ import com.example.recipesapp.databinding.ItemCategoryBinding
 
 import java.io.InputStream
 
-class CategoriesListAdapter(private val dataSet: List<Category>) :
+class CategoriesListAdapter(
+    private val dataSet: List<Category>,
+    private val onItemClick: (Int) -> Unit
+) :
     RecyclerView.Adapter<CategoriesListAdapter.ViewHolder>() {
-
-    private var itemClickListener: OnItemClickListener? = null
-
-    interface OnItemClickListener {
-        fun onItemClick(category: Category)
-    }
-
-    fun setOnItemClickListener(listener: OnItemClickListener) {
-        itemClickListener = listener
-    }
 
     class ViewHolder(val binding: ItemCategoryBinding) :
         RecyclerView.ViewHolder(binding.root)
@@ -57,7 +50,7 @@ class CategoriesListAdapter(private val dataSet: List<Category>) :
         )
 
         binding.root.setOnClickListener {
-            itemClickListener?.onItemClick(category)
+            onItemClick(category.id)
         }
     }
 

--- a/app/src/main/java/com/example/recipesapp/CategoriesListFragment.kt
+++ b/app/src/main/java/com/example/recipesapp/CategoriesListFragment.kt
@@ -1,11 +1,11 @@
 package com.example.recipesapp
 
-import android.content.Context
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.os.bundleOf
 import com.example.recipesapp.databinding.FragmentListCategoriesBinding
 
 class CategoriesListFragment : Fragment() {
@@ -15,16 +15,11 @@ class CategoriesListFragment : Fragment() {
         get() = _categoriesBinding
             ?: throw IllegalStateException("Binding for FragmentListCategoriesBinding must not be null")
 
-    private var navigationListener: OnNavigationListener? = null
-
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-
-        if (context is OnNavigationListener) {
-            navigationListener = context
-        } else {
-            throw RuntimeException("$context must implement OnNavigationListener")
-        }
+    private val navigationListener: OnNavigationListener by lazy {
+        (activity as? OnNavigationListener)
+            ?: throw RuntimeException(
+                "${requireActivity()::class::qualifiedName} must implement OnNavigationListener"
+            )
     }
 
     override fun onCreateView(
@@ -57,19 +52,25 @@ class CategoriesListFragment : Fragment() {
             val categoryName = selectedCategory.title
             val categoryImageUrl = selectedCategory.imageUrl
 
-            val bundle = Bundle().apply {
-                putInt(RecipesListFragment.ARG_CATEGORY_ID, categoryId)
-                putString(RecipesListFragment.ARG_CATEGORY_NAME, categoryName)
-                putString(RecipesListFragment.ARG_CATEGORY_IMAGE_URL, categoryImageUrl)
-            }
+            val bundle = bundleOf(
+                ARG_CATEGORY_ID to categoryId,
+                ARG_CATEGORY_NAME to categoryName,
+                ARG_CATEGORY_IMAGE_URL to categoryImageUrl
+            )
 
-            navigationListener?.navigateToRecipes(bundle)
+            navigationListener.navigateToRecipes(bundle)
         }
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         _categoriesBinding = null
+    }
+
+    companion object {
+        const val ARG_CATEGORY_ID = "category_id"
+        const val ARG_CATEGORY_NAME = "category_name"
+        const val ARG_CATEGORY_IMAGE_URL = "category_image_url"
     }
 
 }

--- a/app/src/main/java/com/example/recipesapp/MainActivity.kt
+++ b/app/src/main/java/com/example/recipesapp/MainActivity.kt
@@ -10,7 +10,7 @@ import androidx.fragment.app.commit
 import androidx.fragment.app.replace
 import com.example.recipesapp.databinding.ActivityMainBinding
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : AppCompatActivity(), OnNavigationListener {
 
     private var _binding: ActivityMainBinding? = null
     private val binding: ActivityMainBinding
@@ -36,11 +36,32 @@ class MainActivity : AppCompatActivity() {
         }
 
         binding.buttonCategory.setOnClickListener {
-            navigateToFragment<CategoriesListFragment>()
+            navigateToCategories()
         }
 
         binding.buttonFavorites.setOnClickListener {
-            navigateToFragment<FavoritesFragment>()
+            navigateToFavorites()
+        }
+    }
+
+    override fun navigateToCategories() {
+        navigateToFragment<CategoriesListFragment>()
+    }
+
+    override fun navigateToFavorites() {
+        navigateToFragment<FavoritesFragment>()
+    }
+
+    override fun navigateToRecipes(bundle: Bundle) {
+        val recipesListFragment = RecipesListFragment.newInstance(
+            bundle.getInt(RecipesListFragment.ARG_CATEGORY_ID),
+            bundle.getString(RecipesListFragment.ARG_CATEGORY_NAME) ?: "",
+            bundle.getString(RecipesListFragment.ARG_CATEGORY_IMAGE_URL) ?: ""
+        )
+        supportFragmentManager.commit {
+            setReorderingAllowed(true)
+            replace(R.id.mainContainer, recipesListFragment)
+            addToBackStack(null)
         }
     }
 

--- a/app/src/main/java/com/example/recipesapp/MainActivity.kt
+++ b/app/src/main/java/com/example/recipesapp/MainActivity.kt
@@ -45,19 +45,17 @@ class MainActivity : AppCompatActivity(), OnNavigationListener {
     }
 
     override fun navigateToCategories() {
-        navigateToFragment<CategoriesListFragment>()
+        if (supportFragmentManager.findFragmentById(R.id.mainContainer) !is CategoriesListFragment)
+            navigateToFragment<CategoriesListFragment>()
     }
 
     override fun navigateToFavorites() {
-        navigateToFragment<FavoritesFragment>()
+        if (supportFragmentManager.findFragmentById(R.id.mainContainer) !is FavoritesFragment)
+            navigateToFragment<FavoritesFragment>()
     }
 
     override fun navigateToRecipes(bundle: Bundle) {
-        val recipesListFragment = RecipesListFragment.newInstance(
-            bundle.getInt(RecipesListFragment.ARG_CATEGORY_ID),
-            bundle.getString(RecipesListFragment.ARG_CATEGORY_NAME) ?: "",
-            bundle.getString(RecipesListFragment.ARG_CATEGORY_IMAGE_URL) ?: ""
-        )
+        val recipesListFragment = RecipesListFragment.newInstance(bundle)
         supportFragmentManager.commit {
             setReorderingAllowed(true)
             replace(R.id.mainContainer, recipesListFragment)
@@ -71,8 +69,6 @@ class MainActivity : AppCompatActivity(), OnNavigationListener {
     }
 
     private inline fun <reified T : Fragment> navigateToFragment() {
-        supportFragmentManager.popBackStack()
-
         supportFragmentManager.commit {
             setReorderingAllowed(true)
             replace<T>(binding.mainContainer.id)

--- a/app/src/main/java/com/example/recipesapp/OnNavigationListener.kt
+++ b/app/src/main/java/com/example/recipesapp/OnNavigationListener.kt
@@ -1,0 +1,9 @@
+package com.example.recipesapp
+
+import android.os.Bundle
+
+interface OnNavigationListener {
+    fun navigateToCategories()
+    fun navigateToFavorites()
+    fun navigateToRecipes(bundle: Bundle)
+}

--- a/app/src/main/java/com/example/recipesapp/RecipesListFragment.kt
+++ b/app/src/main/java/com/example/recipesapp/RecipesListFragment.kt
@@ -32,9 +32,11 @@ class RecipesListFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        categoryId = requireArguments().getInt(ARG_CATEGORY_ID)
-        categoryName = requireArguments().getString(ARG_CATEGORY_NAME) ?: ""
-        categoryImageUrl = requireArguments().getString(ARG_CATEGORY_IMAGE_URL) ?: ""
+        arguments?.let { bundle ->
+            categoryId = bundle.getInt(CategoriesListFragment.ARG_CATEGORY_ID)
+            categoryName = bundle.getString(CategoriesListFragment.ARG_CATEGORY_NAME) ?: ""
+            categoryImageUrl = bundle.getString(CategoriesListFragment.ARG_CATEGORY_IMAGE_URL) ?: ""
+        }
 
         recipesBinding.tvCategoryName.text = categoryName
 
@@ -61,24 +63,8 @@ class RecipesListFragment : Fragment() {
     }
 
     companion object {
-        const val ARG_CATEGORY_ID = "category_id"
-        const val ARG_CATEGORY_NAME = "category_name"
-        const val ARG_CATEGORY_IMAGE_URL = "category_image_url"
-
-        fun newInstance(
-            categoryId: Int,
-            categoryName: String,
-            categoryImageUrl: String,
-        ): RecipesListFragment {
-            val fragment = RecipesListFragment()
-            val args = Bundle().apply {
-                putInt(ARG_CATEGORY_ID, categoryId)
-                putString(ARG_CATEGORY_NAME, categoryName)
-                putString(ARG_CATEGORY_IMAGE_URL, categoryImageUrl)
-            }
-
-            fragment.arguments = args
-            return fragment
+        fun newInstance(args: Bundle) = RecipesListFragment().apply {
+            arguments = args
         }
     }
 

--- a/app/src/main/java/com/example/recipesapp/RecipesListFragment.kt
+++ b/app/src/main/java/com/example/recipesapp/RecipesListFragment.kt
@@ -1,11 +1,14 @@
 package com.example.recipesapp
 
+import android.graphics.drawable.Drawable
 import android.os.Bundle
+import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import com.example.recipesapp.databinding.FragmentListRecipesBinding
+import java.io.InputStream
 
 class RecipesListFragment : Fragment() {
 
@@ -13,6 +16,10 @@ class RecipesListFragment : Fragment() {
     private val recipesBinding: FragmentListRecipesBinding
         get() = _recipesBinding
             ?: throw IllegalStateException("Binding for FragmentListRecipesBinding must not be null")
+
+    private var categoryId: Int = 0
+    private var categoryName: String = ""
+    private var categoryImageUrl: String = ""
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -22,8 +29,57 @@ class RecipesListFragment : Fragment() {
         return recipesBinding.root
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        categoryId = requireArguments().getInt(ARG_CATEGORY_ID)
+        categoryName = requireArguments().getString(ARG_CATEGORY_NAME) ?: ""
+        categoryImageUrl = requireArguments().getString(ARG_CATEGORY_IMAGE_URL) ?: ""
+
+        recipesBinding.tvCategoryName.text = categoryName
+
+        categoryImageUrl.let { imageUrl ->
+            try {
+                val inputStream: InputStream? = context?.assets?.open(imageUrl)
+                val drawable = Drawable.createFromStream(inputStream, null)
+                recipesBinding.ivCategoryCoverImage.setImageDrawable(drawable)
+                inputStream?.close()
+            } catch (e: Exception) {
+                Log.e("RecipesListFragment", "Image not found $imageUrl", e)
+            }
+        }
+        recipesBinding.ivCategoryCoverImage.contentDescription = getString(
+            R.string.category_image_description,
+            categoryName
+        )
+
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
         _recipesBinding = null
     }
+
+    companion object {
+        const val ARG_CATEGORY_ID = "category_id"
+        const val ARG_CATEGORY_NAME = "category_name"
+        const val ARG_CATEGORY_IMAGE_URL = "category_image_url"
+
+        fun newInstance(
+            categoryId: Int,
+            categoryName: String,
+            categoryImageUrl: String,
+        ): RecipesListFragment {
+            val fragment = RecipesListFragment()
+            val args = Bundle().apply {
+                putInt(ARG_CATEGORY_ID, categoryId)
+                putString(ARG_CATEGORY_NAME, categoryName)
+                putString(ARG_CATEGORY_IMAGE_URL, categoryImageUrl)
+            }
+
+            fragment.arguments = args
+            return fragment
+        }
+    }
+
 }

--- a/app/src/main/res/layout/fragment_list_recipes.xml
+++ b/app/src/main/res/layout/fragment_list_recipes.xml
@@ -1,15 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
     android:background="@color/backgroundColor"
+    android:orientation="vertical"
     tools:context=".RecipesListFragment">
 
-    <TextView
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:text="RecipesListFragment" />
+        android:layout_height="224dp">
+
+        <ImageView
+            android:id="@+id/ivCategoryCoverImage"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scaleType="centerCrop"
+            tools:ignore="ContentDescription"
+            tools:src="@drawable/bcg_categories" />
+
+        <TextView
+            android:id="@+id/tvCategoryName"
+            style="@style/ShapeDrawable"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_standard"
+            android:layout_marginBottom="@dimen/margin_standard"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            tools:text="RecipesListFragment" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </FrameLayout>


### PR DESCRIPTION
Стек навигации по фрагментам ведёт себя не так, как хотелось бы.
Если мы переходим от категорий рецептов к самим рецептам, а после открываем "Избранное", то стек должен выглядеть следующим образом:

_CategoriesListFragment->RecipesListFragment->FavoritesFragment_

Однако на деле мы получаем стек:

_CategoriesListFragment->FavoritesFragment_

Нажатие кнопки "Назад" с экрана "Избранное", при условии. что мы перешли на него из "Рецептов", возвращает нас обратно не в "Рецепты", а в "Список категорий".
Причина очевидна: **supportFragmentManager.popBackStack()** в MainActivity, который и удаляет наш RecipesListFragment из стека.

Однако, если избавиться от popBackStack(), то в стеке навигации будут сохраняться наши предыдущие фрагменты, в том числе и вызванные по нескольку раз (актуально для кнопки "Избранное", которую мы можем бесконечно спамить кликами). Вот и получается, что исправление одного бага с несколькими экранами "Избранное" в стеке породило новую брешь с удалением RecipesListFragment из стека. Исправить эту проблему у меня не получилось.

Что касается основной задачи, то я сильно пожалел, что решил централизовать навигацию через MainActivity. Пришлось сидеть над этим три вечера. И то, сам не до конца понял, что сделал. Но вроде работает