### PR TITLE
RA-25 Updating RecipeState when portionCount changes

### DIFF
--- a/app/src/main/java/com/example/recipesapp/ui/IngredientsAdapter.kt
+++ b/app/src/main/java/com/example/recipesapp/ui/IngredientsAdapter.kt
@@ -10,7 +10,7 @@ import java.math.BigDecimal
 import java.math.RoundingMode
 
 class IngredientsAdapter(
-    private val dataSet: List<Ingredient>
+    private var dataSet: List<Ingredient>
 ) :
     RecyclerView.Adapter<IngredientsAdapter.ViewHolder>() {
 
@@ -50,6 +50,10 @@ class IngredientsAdapter(
                 ingredient.unitOfMeasure
             )
         }
+    }
+
+    fun updateData(ingredients: List<Ingredient>) {
+        this.dataSet = ingredients
     }
 
     override fun getItemCount() = dataSet.size

--- a/app/src/main/java/com/example/recipesapp/ui/MethodAdapter.kt
+++ b/app/src/main/java/com/example/recipesapp/ui/MethodAdapter.kt
@@ -7,7 +7,7 @@ import com.example.recipesapp.R
 import com.example.recipesapp.databinding.ItemMethodBinding
 
 class MethodAdapter(
-    private val dataSet: List<String>
+    private var dataSet: List<String>
 ) : RecyclerView.Adapter<MethodAdapter.ViewHolder>() {
 
     class ViewHolder(val binding: ItemMethodBinding) :
@@ -32,6 +32,10 @@ class MethodAdapter(
                 step
             )
         }
+    }
+
+    fun updateData(method: List<String>) {
+        this.dataSet = method
     }
 
     override fun getItemCount() = dataSet.size

--- a/app/src/main/java/com/example/recipesapp/ui/recipes/detail/RecipeViewModel.kt
+++ b/app/src/main/java/com/example/recipesapp/ui/recipes/detail/RecipeViewModel.kt
@@ -78,6 +78,10 @@ class RecipeViewModel(application: Application) : AndroidViewModel(application) 
         _state.value = _state.value?.copy(isFavorite = !isCurrentlyFavorite)
     }
 
+    fun updatePortionCount(portionCount: Int) {
+        _state.value = _state.value?.copy(portionCount = portionCount)
+    }
+
     companion object {
         private const val SHARED_PREFS_NAME = "favorite_recipes_prefs"
         private const val FAVORITES_KEY = "favorites_recipes"


### PR DESCRIPTION
Долго мучился с решением, чтобы соответствовать требованию - единственный источник данных state внутри observer.
Речь идёт о проблемах с инициализацией RecyclerView. Если запихнуть всё в observer, то при обновлении счётчика порций декораторы списка накладывались друг на друга. Из-за этого списки раздувались.
В итоге, чтобы решить задачу, потребовалось добавить дополнительные методы обновления адаптеров. 