### PR TITLE
RA-39 Caching implementation for Category list

### DIFF
--- a/app/src/main/java/com/example/recipesapp/common/Constants.kt
+++ b/app/src/main/java/com/example/recipesapp/common/Constants.kt
@@ -3,4 +3,6 @@ package com.example.recipesapp.common
 object Constants {
     const val BASE_URL = "https://recipes.androidsprint.ru/api/"
     const val IMAGES_PATH = "images/"
+    const val SHARED_PREFS_NAME = "favorite_recipes_prefs"
+    const val FAVORITES_KEY = "favorites_recipes"
 }

--- a/app/src/main/java/com/example/recipesapp/data/AppDatabase.kt
+++ b/app/src/main/java/com/example/recipesapp/data/AppDatabase.kt
@@ -1,0 +1,31 @@
+package com.example.recipesapp.data
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import com.example.recipesapp.model.Category
+
+@Database(entities = [Category::class], version = 1, exportSchema = false)
+abstract class AppDatabase: RoomDatabase() {
+
+    abstract fun categoriesDao() : CategoriesDao
+
+    companion object {
+        @Volatile
+        private var instance: AppDatabase? = null
+
+        fun getDatabase(context: Context): AppDatabase {
+            return instance ?: synchronized(this) {
+                val newInstance = Room.databaseBuilder(
+                    context.applicationContext,
+                    AppDatabase::class.java,
+                    "recipes_database"
+                ).build()
+                instance = newInstance
+                newInstance
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/example/recipesapp/data/CategoriesDao.kt
+++ b/app/src/main/java/com/example/recipesapp/data/CategoriesDao.kt
@@ -1,0 +1,17 @@
+package com.example.recipesapp.data
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.example.recipesapp.model.Category
+
+@Dao
+interface CategoriesDao {
+
+    @Query("SELECT * FROM category")
+    fun getAllCategories() : List<Category>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun addCategory(category: List<Category>)
+}

--- a/app/src/main/java/com/example/recipesapp/data/RecipesRepository.kt
+++ b/app/src/main/java/com/example/recipesapp/data/RecipesRepository.kt
@@ -18,7 +18,10 @@ import java.util.concurrent.TimeUnit
 class RecipesRepository(
     private val apiService: RecipeApiService = createApiService(),
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    database: AppDatabase,
 ) {
+
+    private val categoriesDao: CategoriesDao = database.categoriesDao()
 
     companion object {
         private const val CONNECTION_TIMEOUT = 10_000L
@@ -47,29 +50,9 @@ class RecipesRepository(
         }
     }
 
-    /*private val apiService: RecipeApiService
-
-    init {
-        val loggingInterceptor = HttpLoggingInterceptor().apply {
-            level = HttpLoggingInterceptor.Level.BODY
-        }
-
-
-        val okHttpClient = OkHttpClient.Builder()
-            .addInterceptor(loggingInterceptor)
-            .connectTimeout(CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS)
-            .readTimeout(READ_TIMEOUT, TimeUnit.MILLISECONDS)
-            .build()
-
-
-        val retrofit = Retrofit.Builder()
-            .baseUrl(Constants.BASE_URL)
-            .client(okHttpClient)
-            .addConverterFactory(GsonConverterFactory.create())
-            .build()
-
-        apiService = retrofit.create(RecipeApiService::class.java)
-    }*/
+    suspend fun getCategoriesFromCache(): List<Category> = withContext(ioDispatcher) {
+        categoriesDao.getAllCategories()
+    }
 
     suspend fun getCategories(): List<Category>? = withContext(ioDispatcher) {
         try {
@@ -130,6 +113,10 @@ class RecipesRepository(
             Log.e("RecipesRepository", "IOException при получении рецепта по ID", e)
             null
         }
+    }
+
+    suspend fun saveCategoriesToCache(categories: List<Category>) = withContext(ioDispatcher) {
+        categoriesDao.addCategory(categories)
     }
 
 }

--- a/app/src/main/java/com/example/recipesapp/model/Category.kt
+++ b/app/src/main/java/com/example/recipesapp/model/Category.kt
@@ -12,5 +12,5 @@ data class Category(
     @PrimaryKey val id: Int,
     @ColumnInfo(name = "recipe_title") val title: String,
     @ColumnInfo(name = "recipe_description") val description: String,
-    @ColumnInfo(name = "recipe_imageUrl") val imageUrl: String,
+    @ColumnInfo(name = "recipe_image_url") val imageUrl: String,
 ) : Parcelable

--- a/app/src/main/java/com/example/recipesapp/model/Category.kt
+++ b/app/src/main/java/com/example/recipesapp/model/Category.kt
@@ -1,12 +1,16 @@
 package com.example.recipesapp.model
 
 import android.os.Parcelable
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
+@Entity
 data class Category(
-    val id: Int,
-    val title: String,
-    val description: String,
-    val imageUrl: String,
+    @PrimaryKey val id: Int,
+    @ColumnInfo(name = "recipe_title") val title: String,
+    @ColumnInfo(name = "recipe_description") val description: String,
+    @ColumnInfo(name = "recipe_imageUrl") val imageUrl: String,
 ) : Parcelable

--- a/app/src/main/java/com/example/recipesapp/ui/categories/CategoriesListViewModel.kt
+++ b/app/src/main/java/com/example/recipesapp/ui/categories/CategoriesListViewModel.kt
@@ -33,29 +33,30 @@ class CategoriesListViewModel(application: Application) : AndroidViewModel(appli
 
             val cachedCategories = recipesRepository.getCategoriesFromCache()
 
-            if (cachedCategories.isNotEmpty()) {
+            if (cachedCategories.isEmpty()) {
+                val networkCategories = recipesRepository.getCategories()
+
+                if (networkCategories != null) {
+                    recipesRepository.saveCategoriesToCache(networkCategories)
+
+                    val updatedCategories = networkCategories.map { category ->
+                        category.copy(imageUrl = Constants.BASE_URL + Constants.IMAGES_PATH + category.imageUrl)
+                    }
+                    _state.value = _state.value?.copy(
+                        categories = updatedCategories,
+                        error = null,
+                    )
+                } else {
+                    _state.value = _state.value?.copy(
+                        error = ErrorType.DATA_FETCH_ERROR,
+                    )
+                }
+            } else {
                 val updatedCategories = cachedCategories.map { category ->
                     category.copy(imageUrl = Constants.BASE_URL + Constants.IMAGES_PATH + category.imageUrl)
                 }
                 _state.value = _state.value?.copy(
-                    categories = updatedCategories,
-                )
-            }
-
-            val networkCategories = recipesRepository.getCategories()
-            if (networkCategories != null) {
-                recipesRepository.saveCategoriesToCache(networkCategories)
-
-                val updatedCategories = networkCategories.map { category ->
-                    category.copy(imageUrl = Constants.BASE_URL + Constants.IMAGES_PATH + category.imageUrl)
-                }
-                _state.value = _state.value?.copy(
-                    categories = updatedCategories,
-                    error = null,
-                )
-            } else {
-                _state.value = _state.value?.copy(
-                    error = ErrorType.DATA_FETCH_ERROR,
+                    categories =  updatedCategories,
                 )
             }
         }

--- a/app/src/main/java/com/example/recipesapp/ui/recipes/detail/RecipeViewModel.kt
+++ b/app/src/main/java/com/example/recipesapp/ui/recipes/detail/RecipeViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.example.recipesapp.common.Constants
+import com.example.recipesapp.data.AppDatabase
 import com.example.recipesapp.data.RecipesRepository
 import com.example.recipesapp.model.ErrorType
 import com.example.recipesapp.model.Recipe
@@ -15,7 +16,9 @@ import kotlinx.coroutines.launch
 
 class RecipeViewModel(application: Application) : AndroidViewModel(application) {
 
-    private val recipesRepository = RecipesRepository()
+    private val database = AppDatabase.getDatabase(application)
+
+    private val recipesRepository = RecipesRepository(database = database)
 
     private val _state = MutableLiveData(RecipeState())
     val state: LiveData<RecipeState>
@@ -72,11 +75,11 @@ class RecipeViewModel(application: Application) : AndroidViewModel(application) 
     private fun getFavorites(): MutableSet<String> {
         val sharedPrefs =
             getApplication<Application>().getSharedPreferences(
-                SHARED_PREFS_NAME,
+                Constants.SHARED_PREFS_NAME,
                 Context.MODE_PRIVATE
             )
         val favorites =
-            sharedPrefs.getStringSet(FAVORITES_KEY, emptySet()) ?: emptySet()
+            sharedPrefs.getStringSet(Constants.FAVORITES_KEY, emptySet()) ?: emptySet()
 
         return HashSet(favorites)
     }
@@ -84,10 +87,10 @@ class RecipeViewModel(application: Application) : AndroidViewModel(application) 
     private fun saveFavorites(favorites: Set<String>) {
         val sharedPrefs =
             getApplication<Application>().getSharedPreferences(
-                SHARED_PREFS_NAME,
+                Constants.SHARED_PREFS_NAME,
                 Context.MODE_PRIVATE
             )
-        sharedPrefs.edit().putStringSet(FAVORITES_KEY, favorites).apply()
+        sharedPrefs.edit().putStringSet(Constants.FAVORITES_KEY, favorites).apply()
     }
 
     fun onFavoritesClicked() {
@@ -112,10 +115,4 @@ class RecipeViewModel(application: Application) : AndroidViewModel(application) 
     fun clearError() {
         _state.postValue(_state.value?.copy(error = null))
     }
-
-    companion object {
-        private const val SHARED_PREFS_NAME = "favorite_recipes_prefs"
-        private const val FAVORITES_KEY = "favorites_recipes"
-    }
-
 }

--- a/app/src/main/java/com/example/recipesapp/ui/recipes/favorites/FavoritesViewModel.kt
+++ b/app/src/main/java/com/example/recipesapp/ui/recipes/favorites/FavoritesViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.example.recipesapp.common.Constants
+import com.example.recipesapp.data.AppDatabase
 import com.example.recipesapp.data.RecipesRepository
 import com.example.recipesapp.model.ErrorType
 import com.example.recipesapp.model.Recipe
@@ -15,7 +16,9 @@ import kotlinx.coroutines.launch
 
 class FavoritesViewModel(application: Application) : AndroidViewModel(application) {
 
-    private val recipesRepository = RecipesRepository()
+    private val database = AppDatabase.getDatabase(application)
+
+    private val recipesRepository = RecipesRepository(database = database)
 
     private val _state = MutableLiveData(FavoritesState())
     val state: LiveData<FavoritesState>
@@ -94,21 +97,16 @@ class FavoritesViewModel(application: Application) : AndroidViewModel(applicatio
     private fun getFavorites(): Set<Int> {
         val sharedPreferences =
             getApplication<Application>().getSharedPreferences(
-                SHARED_PREFS_NAME,
+                Constants.SHARED_PREFS_NAME,
                 Context.MODE_PRIVATE
             )
         val favoriteIdsStringSet =
-            sharedPreferences.getStringSet(FAVORITES_KEY, emptySet()) ?: emptySet()
+            sharedPreferences.getStringSet(Constants.FAVORITES_KEY, emptySet()) ?: emptySet()
 
         return favoriteIdsStringSet.mapNotNull { it.toIntOrNull() }.toSet()
     }
 
     fun clearError() {
         _state.postValue(_state.value?.copy(error = null))
-    }
-
-    companion object {
-        private const val SHARED_PREFS_NAME = "favorite_recipes_prefs"
-        private const val FAVORITES_KEY = "favorites_recipes"
     }
 }

--- a/app/src/main/java/com/example/recipesapp/ui/recipes/list/RecipesListViewModel.kt
+++ b/app/src/main/java/com/example/recipesapp/ui/recipes/list/RecipesListViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.example.recipesapp.common.Constants
+import com.example.recipesapp.data.AppDatabase
 import com.example.recipesapp.data.RecipesRepository
 import com.example.recipesapp.model.Category
 import com.example.recipesapp.model.ErrorType
@@ -15,7 +16,9 @@ import kotlinx.coroutines.launch
 
 class RecipesListViewModel(application: Application) : AndroidViewModel(application) {
 
-    private val recipesRepository = RecipesRepository()
+    private val database = AppDatabase.getDatabase(application)
+
+    private val recipesRepository = RecipesRepository(database = database)
 
     private val _state = MutableLiveData(RecipesListState())
     val state: LiveData<RecipesListState>


### PR DESCRIPTION
Нашёл вот такую интересную реализацию гарантированно единственного экземпляра базы данных в приложении через паттерн синглтона. Разобрал её, чтобы полностью понять.
```
companion object {
        @Volatile
        private var instance: AppDatabase? = null

        fun getDatabase(context: Context): AppDatabase {
            return instance ?: synchronized(this) {
                val newInstance = Room.databaseBuilder(
                    context.applicationContext,
                    AppDatabase::class.java,
                    "recipes_database"
                ).build()
                instance = newInstance
                newInstance
            }
        }
    }
```
 Ещё хотел уточнить, нужно ли у интерфейса CategoriesDao делать функции suspend, чтобы асинхронно выполнять операции, связанные с базой данных?